### PR TITLE
Fix errors caused by mutations on certain elements

### DIFF
--- a/src/js/taos.js
+++ b/src/js/taos.js
@@ -74,7 +74,7 @@
 
   const observer = new MutationObserver(mutations => {
     mutations.forEach(({target}) => {
-      if (!target.className.includes('taos-init') && target.className.includes('taos:')) {
+      if (target.className.includes && !target.className.includes('taos-init') && target.className.includes('taos:')) {
         elements.push(initElement(target))
       }
     })


### PR DESCRIPTION
In my use case, we are having to modify the `d` attribute on a `path` element inside of an `svg` tag. This is triggering the MutationObserver. However, the `Node` object returned by the `path` element in javascript is not compatible with the expectations in this observer. It still has a `className` property, but it is not a string type but a `SVGAnimatedString`. This `SVGAnimatedString` type does not have an `includes` property causing these calls to error out.

While it may not be the most elegant fix, adding in a check to see if the includes property is defined fixes this error in my specific use case.