### PR TITLE
Fallback replaceAll for older browsers

### DIFF
--- a/src/js/taos.js
+++ b/src/js/taos.js
@@ -23,7 +23,15 @@
       element.className = element.dataset.taosClass
     }
   }
-  const before = element => element.className = element.className.replaceAll('taos:', '')
+  const before = element => {
+    if (!String.prototype.replaceAll) {
+      // Fallback for browsers that do not support 'replaceAll'
+      element.className = element.className.split('taos:').join('');
+    } else {
+      // Use 'replaceAll' if available
+      element.className = element.className.replaceAll('taos:', '');
+    }
+  }
 
   const initElement = element => {
     if (!element.className.includes('taos-init')) {


### PR DESCRIPTION
Since "replaceAll" was introduced first in ES2021, it breaks websites that are using TAOS. Instead a fallback combination of "split" and "join" is used.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll#browser_compatibility