### PR TITLE
Add support for turbo-rails

### DIFF
--- a/src/js/taos.js
+++ b/src/js/taos.js
@@ -50,7 +50,7 @@
 
   const refresh = () => {
     elements = []
-    document.querySelectorAll('[class*="Taos"]').forEach(el => elements.push(initElement(el)))
+    document.querySelectorAll('[class*="taos"]').forEach(el => elements.push(initElement(el)))
     refreshTriggers()
     requestAnimationFrame(handleScroll)
   }

--- a/src/js/taos.js
+++ b/src/js/taos.js
@@ -50,7 +50,7 @@
 
   const refresh = () => {
     elements = []
-    document.querySelectorAll('[class*="taos"]').forEach(el => elements.push(initElement(el)))
+    document.querySelectorAll('[class*="Taos"]').forEach(el => elements.push(initElement(el)))
     refreshTriggers()
     requestAnimationFrame(handleScroll)
   }
@@ -78,6 +78,7 @@
   refresh()
   addEventListener('scroll', throttle(handleScroll, 32))
   addEventListener('orientationchange', refresh)
+  addEventListener('turbo:load', refresh)
   addEventListener('resize', debounce(handleResize, 250))
 
   const observer = new MutationObserver(mutations => {


### PR DESCRIPTION
At the moment, visits through turbo do not refresh the animations so the animations completely disappear. This fixes it.


Ref: https://turbo.hotwired.dev/reference/events
