### PR TITLE
Fix uncaught TypeError caused by `SVGAnimatedString` type `className`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taos",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "TAOS - Tailwind CSS Animation on Scroll Library",
   "keywords": [
     "taos",

--- a/src/js/taos.js
+++ b/src/js/taos.js
@@ -82,7 +82,7 @@
 
   const observer = new MutationObserver(mutations => {
     mutations.forEach(({target}) => {
-      const classes = target.getAttribute('class') || "";
+      const classes = (target && target.getAttribute('class')) || "";
 
       if (classes && !classes.includes('taos-init') && classes.includes('taos:')) {
         elements.push(initElement(target))

--- a/src/js/taos.js
+++ b/src/js/taos.js
@@ -83,7 +83,6 @@
   const observer = new MutationObserver(mutations => {
     mutations.forEach(({target}) => {
       const classes = (target && target.getAttribute('class')) || "";
-
       if (classes && !classes.includes('taos-init') && classes.includes('taos:')) {
         elements.push(initElement(target))
       }

--- a/src/js/taos.js
+++ b/src/js/taos.js
@@ -82,7 +82,9 @@
 
   const observer = new MutationObserver(mutations => {
     mutations.forEach(({target}) => {
-      if (target.className && !target.className.includes('taos-init') && target.className.includes('taos:')) {
+      const classes = target.getAttribute('class') || "";
+
+      if (classes && !classes.includes('taos-init') && classes.includes('taos:')) {
         elements.push(initElement(target))
       }
     })


### PR DESCRIPTION
## Problem

```
taos.js:85 Uncaught TypeError: e4.className.includes is not a function
    at taos.js:85:49
    at Array.forEach (<anonymous>)
    at MutationObserver.observe.attributes (taos.js:84:15)
```

## Root Cause

According to MDN: `className can [...] be an instance of SVGAnimatedString if the element is an SVGElement.`

This error is thrown when the MutationObserver receives an SVG element with a `SVGAnimatedString` type className.

## Solution

Use `Element.getAttribute` instead of directly referencing className, as suggested by MDN.

https://developer.mozilla.org/en-US/docs/Web/API/Element/className#notes

